### PR TITLE
Close leader selectors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.22
+version=0.0.23-SNAPSHOT

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerLeader.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerLeader.java
@@ -12,7 +12,6 @@ import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.utils.CloseableExecutorService;
-import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.utils.ThreadUtils;
 
 import org.apache.zookeeper.CreateMode;
@@ -109,7 +108,7 @@ abstract class ZKConsumerLeader<T> {
         final LeaderSelector leaderSelector = leaderSelectors.remove(t);
         if (null != leaderSelector) {
             LOGGER.info("Close member [{}] leadership for [{}]", member.getMemberId(), t);
-            CloseableUtils.closeQuietly(leaderSelector);
+            leaderSelector.close();
         }
     }
 

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerLeader.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerLeader.java
@@ -9,9 +9,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -35,14 +32,13 @@ abstract class ZKConsumerLeader<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZKConsumerLeader.class);
 
+    private static final long WAIT_MILLIS_BEFORE_CLOSING_LEADER_SELECTOR = 1000L;
+
     private final ZKMember member;
 
     private final ZKHolder zkHolder;
 
     private final String consumerName;
-
-    private final ScheduledExecutorService closeLeaderSelectorExecutorService = Executors
-            .newSingleThreadScheduledExecutor();
 
     ZKConsumerLeader(final ZKHolder zkHolder, final String consumerName, final ZKMember member) {
         this.zkHolder = requireNonNull(zkHolder, "zkHolder must not be null");
@@ -127,14 +123,8 @@ abstract class ZKConsumerLeader<T> {
                             leadershipChangedListener.takeLeadership(t, member);
                             leaderControl.takeLeadership();
                         } finally {
-                            try {
-                                LOGGER.info("Member [{}] relinquished leadership for [{}]", member.getMemberId(), t);
-
-                                final LeaderControl leaderControl = leaderControls.remove(t);
-                                closeLeaderSelectorAsync(leaderControl.selector);
-                            } finally {
-                                leadershipChangedListener.relinquishLeadership(t, member);
-                            }
+                            LOGGER.info("Member [{}] relinquished leadership for [{}]", member.getMemberId(), t);
+                            leadershipChangedListener.relinquishLeadership(t, member);
                         }
                     }
 
@@ -164,6 +154,8 @@ abstract class ZKConsumerLeader<T> {
             LOGGER.info("Init member [{}] leadership for [{}]", member.getMemberId(), t);
 
             // restart selector every time the leadership is lost
+            selector.autoRequeue();
+
             try {
                 selector.start();
             } catch (final Throwable throwable) {
@@ -188,12 +180,35 @@ abstract class ZKConsumerLeader<T> {
         if (null != leaderControl) {
             LOGGER.info("Close member [{}] leadership for [{}]", member.getMemberId(), t);
             leaderControl.relinquishLeadership();
+
+            try {
+                Thread.sleep(WAIT_MILLIS_BEFORE_CLOSING_LEADER_SELECTOR);
+            } catch (InterruptedException e) {
+                ThrowableUtils.throwException(e);
+            }
+
+            leaderControl.selector.close();
         }
     }
 
     public void close() {
         LOGGER.info("Closing for member [{}]", member.getMemberId());
+
         leaderControls.values().forEach(LeaderControl::relinquishLeadership);
+
+        try {
+            Thread.sleep(WAIT_MILLIS_BEFORE_CLOSING_LEADER_SELECTOR);
+        } catch (InterruptedException e) {
+            ThrowableUtils.throwException(e);
+        }
+
+        leaderControls.values().forEach(leaderControl -> {
+            try {
+                leaderControl.selector.close();
+            } catch (Exception e) {
+                LOGGER.warn("Unexpected error while closing leader selector [{}]", e);
+            }
+        });
         leaderControls.clear();
     }
 
@@ -210,22 +225,6 @@ abstract class ZKConsumerLeader<T> {
             curator.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT).forPath(path);
             curator.setData().forPath(path, memberId.getBytes("UTF-8"));
         }
-    }
-
-    private void closeLeaderSelectorAsync(final LeaderSelector leaderSelector) {
-        closeLeaderSelectorExecutorService.schedule(decorateWithExceptionLogger(leaderSelector::close), 1,
-            TimeUnit.SECONDS);
-    }
-
-    private static Runnable decorateWithExceptionLogger(final Runnable runnable) {
-        return
-            () -> {
-            try {
-                runnable.run();
-            } catch (final Exception e) {
-                LOGGER.warn("Unexpected error while closing leader selector", e);
-            }
-        };
     }
 
 }

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinatorTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinatorTest.java
@@ -106,6 +106,12 @@ public class ZKLeaderConsumerPartitionCoordinatorTest extends AbstractZKTest {
         mockRebalancer1.await(4, TimeUnit.SECONDS);
         mockRebalancer1.verify();
         assertThat(getLast(mockRebalancer1.verifyCurrentMembers())).containsOnlyKeys(memberId1, memberId2);
+
+        mockRebalancer1.init(1, 0, 1);
+        coordinator2.close();
+        mockRebalancer1.await(4, TimeUnit.SECONDS);
+        mockRebalancer1.verify();
+        assertThat(getLast(mockRebalancer1.verifyCurrentMembers())).containsOnlyKeys(memberId1);
     }
 
     private ZKLeaderConsumerPartitionCoordinator getCoordinator(final String consumerName,


### PR DESCRIPTION
- Reuse LeaderSelector until  group leadership is closed
- Close instances of LeaderSelector to avoid resource leak
- In LeaderSelectorListener, rely on java thread interrupts to give up leadership
