### PR TITLE
#6 Replace NakadiPartition.getOldestAvailableOffset() with BEGIN

### DIFF
--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
@@ -59,18 +59,18 @@ public class SimplePartitionCoordinator extends AbstractPartitionCoordinator {
 
     private Function<NakadiPartition, EventTypeCursor> getOffsetSelector(final EventType eventType) {
         return
-            entry -> {
+            nakadiPartition -> {
             final String offset;
             if (startNewestAvailableOffset) {
-                offset = entry.getNewestAvailableOffset();
+                offset = nakadiPartition.getNewestAvailableOffset();
             } else {
-                offset = entry.getOldestAvailableOffset();
+                offset = "BEGIN";
 
                 // messages will be replayed on each restart
                 log.warn("Using oldest available offset [{}] without persistent storage.", offset);
             }
 
-            return EventTypeCursor.of(EventTypePartition.of(eventType, entry.getPartition()), offset);
+            return EventTypeCursor.of(EventTypePartition.of(eventType, nakadiPartition.getPartition()), offset);
         };
     }
 

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/AbstractZKConsumerPartitionCoordinator.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/AbstractZKConsumerPartitionCoordinator.java
@@ -71,8 +71,7 @@ abstract class AbstractZKConsumerPartitionCoordinator extends AbstractPartitionC
     }
 
     private String nextOffset(final EventType eventType, final NakadiPartition nakadiPartition) throws Exception {
-        String result = startNewestAvailableOffset ? nakadiPartition.getNewestAvailableOffset()
-                                                   : nakadiPartition.getOldestAvailableOffset();
+        String result = startNewestAvailableOffset ? nakadiPartition.getNewestAvailableOffset() : "BEGIN";
 
         final String path = consumerOffset.getOffsetPath(eventType.getName(), nakadiPartition.getPartition());
         final String zkOffset = consumerOffset.getOffset(path);


### PR DESCRIPTION
- The special cursor value "BEGIN" is used instead of `Long.parseLong(getOldestAvailableOffset()) - 1` so that cursor arithmetics is avoided (see https://github.com/zalando-incubator/paradox-nakadi-consumer/issues/7)