### PR TITLE
Error Handling Added

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.1.0-beta1
+version=0.0.23-RC1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.23-RC1
+version=0.1.0-beta1

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiConsumerConfiguration.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiConsumerConfiguration.java
@@ -1,10 +1,53 @@
 package de.zalando.paradox.nakadi.consumer.boot;
 
+import static java.lang.String.format;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import static de.zalando.paradox.nakadi.consumer.boot.NakadiConsumerProperties.PREFIX;
+
+import java.lang.reflect.Method;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.core.annotation.AnnotationUtils;
+
+import org.springframework.security.oauth2.client.token.AccessTokenProvider;
+
+import org.springframework.util.ReflectionUtils;
+
+import org.zalando.stups.oauth2.spring.client.StupsTokensAccessTokenProvider;
+import org.zalando.stups.tokens.AccessTokens;
+import org.zalando.stups.tokens.config.AccessTokensBeanAutoConfiguration;
+
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
+
 import de.zalando.paradox.nakadi.consumer.boot.components.ConsumerEventConfig;
 import de.zalando.paradox.nakadi.consumer.boot.components.ConsumerEventConfigList;
 import de.zalando.paradox.nakadi.consumer.boot.components.ConsumerPartitionCoordinatorProvider;
+import de.zalando.paradox.nakadi.consumer.boot.components.EventErrorHandlerList;
 import de.zalando.paradox.nakadi.consumer.core.AuthorizationValueProvider;
 import de.zalando.paradox.nakadi.consumer.core.EventHandler;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
@@ -12,34 +55,6 @@ import de.zalando.paradox.nakadi.consumer.core.partitioned.impl.SimplePartitionC
 import de.zalando.paradox.nakadi.consumer.partitioned.zk.ZKHolder;
 import de.zalando.paradox.nakadi.consumer.partitioned.zk.ZKLeaderConsumerPartitionCoordinator;
 import de.zalando.paradox.nakadi.consumer.partitioned.zk.ZKSimpleConsumerPartitionCoordinator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.security.oauth2.client.token.AccessTokenProvider;
-import org.springframework.util.ReflectionUtils;
-import org.zalando.stups.oauth2.spring.client.StupsTokensAccessTokenProvider;
-import org.zalando.stups.tokens.AccessTokens;
-import org.zalando.stups.tokens.config.AccessTokensBeanAutoConfiguration;
-
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static de.zalando.paradox.nakadi.consumer.boot.NakadiConsumerProperties.PREFIX;
-import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Configuration
 @AutoConfigureAfter(AccessTokensBeanAutoConfiguration.class)
@@ -56,10 +71,9 @@ public class NakadiConsumerConfiguration {
 
     @Bean
     public ConsumerEventConfigList consumerEventConfigList() {
-
         final Map<String, EventHandler> handlers = applicationContext.getBeansOfType(EventHandler.class);
-        final List<ConsumerEventConfig> list = handlers.entrySet().stream().map(beanNameHandlerEntry -> {
-            //J-
+        final Function<Map.Entry<String, EventHandler>, List<ConsumerEventConfig>> eventHandlerFunction =
+            beanNameHandlerEntry -> {
             NakadiHandler nakadiHandler = null;
             final Class<?> beanType = beanNameHandlerEntry.getValue().getClass();
             final String beanName = beanNameHandlerEntry.getKey();
@@ -67,73 +81,98 @@ public class NakadiConsumerConfiguration {
             if (null != method) {
                 nakadiHandler = AnnotationUtils.findAnnotation(method, NakadiHandler.class);
             }
+
             if (null == nakadiHandler) {
                 nakadiHandler = AnnotationUtils.findAnnotation(beanType, NakadiHandler.class);
             }
+
             final SetMultimap<String, String> consumerToEvents = LinkedHashMultimap.create();
             if (null != nakadiHandler) {
-                addEventToConsumer(consumerToEvents, nakadiHandler.eventName(), nakadiHandler.consumerName(), nakadiHandler.consumerNamePostfix());
+                addEventToConsumer(consumerToEvents, nakadiHandler.eventName(), nakadiHandler.consumerName(),
+                    nakadiHandler.consumerNamePostfix());
             }
+
             if (NakadiEventHandler.class.isAssignableFrom(beanType)) {
                 final Object bean = applicationContext.getBean(beanName);
                 checkState(bean instanceof NakadiEventHandler, "bean must implement NakadiEventHandler");
+
                 final NakadiEventConsumers nakadiEventConsumers = ((NakadiEventHandler) bean).getNakadiEventConsumers();
                 checkArgument(null != nakadiEventConsumers, "nakadiEventConsumers must not be null");
+
                 final Set<NakadiEventConsumer> beanEventConsumers = nakadiEventConsumers.getEventConsumers();
                 if (null == beanEventConsumers || beanEventConsumers.isEmpty()) {
                     LOGGER.info("Empty Nakadi event consumers provided by [{} / {}]", beanName, beanType);
                 } else {
-                    beanEventConsumers.forEach(eventConsumer -> addEventToConsumer(
-                            consumerToEvents, eventConsumer.getEventName(), eventConsumer.getConsumerName(), false));
+                    beanEventConsumers.forEach(eventConsumer ->
+                            addEventToConsumer(consumerToEvents, eventConsumer.getEventName(),
+                                eventConsumer.getConsumerName(), false));
                 }
             }
-            return consumerToEvents.entries().stream().map(consumerEventEntry -> new ConsumerEventConfig(
-                            consumerEventEntry.getKey(), consumerEventEntry.getValue(), beanNameHandlerEntry.getValue())).
-                    collect(Collectors.toList());
-            //J+
-        }).flatMap(Collection::stream).collect(Collectors.toList());
+
+            return consumerToEvents.entries().stream().map(consumerEventEntry ->
+                                           new ConsumerEventConfig(consumerEventEntry.getKey(),
+                                               consumerEventEntry.getValue(), beanNameHandlerEntry.getValue())).collect(
+                                       Collectors.toList());
+        };
+
+        final List<ConsumerEventConfig> list = handlers.entrySet().stream().map(eventHandlerFunction)
+                                                       .flatMap(Collection::stream).collect(Collectors.toList());
         return new ConsumerEventConfigList(list);
     }
 
-    private void addEventToConsumer(final SetMultimap<String, String> consumerToEvents, final String eventName, final String consumerName,
-                                    final boolean consumerNamePostfix) {
+    private void addEventToConsumer(final SetMultimap<String, String> consumerToEvents, final String eventName,
+            final String consumerName, final boolean consumerNamePostfix) {
         checkArgument(isNotEmpty(eventName), "eventName must not be empty");
 
         final String eventConsumerName;
         if (consumerNamePostfix) {
             checkArgument(isNotEmpty(consumerName), "consumerName for postfix 'true' attribute must not be empty");
-            checkArgument(isNotEmpty(nakadiConsumerProperties.getDefaultConsumerName()), "defaultConsumerName for postfix 'true' attribute must not be empty");
+            checkArgument(isNotEmpty(nakadiConsumerProperties.getDefaultConsumerName()),
+                "defaultConsumerName for postfix 'true' attribute must not be empty");
             eventConsumerName = nakadiConsumerProperties.getDefaultConsumerName() + "-" + consumerName;
         } else {
-            eventConsumerName = isNotEmpty(consumerName) ? consumerName : nakadiConsumerProperties.getDefaultConsumerName();
+            eventConsumerName = isNotEmpty(consumerName) ? consumerName
+                                                         : nakadiConsumerProperties.getDefaultConsumerName();
         }
+
         checkArgument(isNotEmpty(eventConsumerName), "consumerName must not be empty");
         consumerToEvents.put(eventConsumerName, eventName);
     }
 
     @Bean
-    @ConditionalOnProperty(value = "partitionCoordinatorProvider", prefix = PREFIX, matchIfMissing = true, havingValue = "simple")
-    public ConsumerPartitionCoordinatorProvider simplePartitionCoordinatorProvider() {
-        return consumerName -> {
-            final SimplePartitionCoordinator coordinator = new SimplePartitionCoordinator();
+    @ConditionalOnProperty(
+        value = "partitionCoordinatorProvider", prefix = PREFIX, matchIfMissing = true, havingValue = "simple"
+    )
+    public ConsumerPartitionCoordinatorProvider simplePartitionCoordinatorProvider(
+            final EventErrorHandlerList eventErrorHandlerList) {
+        return
+            consumerName -> {
+            final SimplePartitionCoordinator coordinator = new SimplePartitionCoordinator(
+                    eventErrorHandlerList.getEventErrorHandlerList());
             final Boolean value = nakadiConsumerProperties.getStartNewestAvailableOffset();
             if (null != value) {
+
                 // use false only for development as messages will be replayed on each restart
                 coordinator.setStartNewestAvailableOffset(value);
             }
+
             return coordinator;
         };
     }
 
     @Bean
     @ConditionalOnProperty(value = "partitionCoordinatorProvider", prefix = PREFIX, havingValue = "zk")
-    public ConsumerPartitionCoordinatorProvider leaderConsumerPartitionCoordinator(final ZKHolder zkHolder) {
-        return consumerName -> {
-            final ZKLeaderConsumerPartitionCoordinator coordinator = new ZKLeaderConsumerPartitionCoordinator(zkHolder, consumerName);
+    public ConsumerPartitionCoordinatorProvider leaderConsumerPartitionCoordinator(final ZKHolder zkHolder,
+            final EventErrorHandlerList eventErrorHandlerList) {
+        return
+            consumerName -> {
+            final ZKLeaderConsumerPartitionCoordinator coordinator = new ZKLeaderConsumerPartitionCoordinator(zkHolder,
+                    consumerName, eventErrorHandlerList.getEventErrorHandlerList());
             final Boolean value = nakadiConsumerProperties.getStartNewestAvailableOffset();
             if (null != value) {
                 coordinator.setStartNewestAvailableOffset(value);
             }
+
             return coordinator;
         };
     }
@@ -141,19 +180,23 @@ public class NakadiConsumerConfiguration {
     @Bean(initMethod = "init")
     @ConditionalOnProperty(value = "partitionCoordinatorProvider", prefix = PREFIX, havingValue = "zk")
     public ZKHolder zkHolder() {
-        return new ZKHolder(nakadiConsumerProperties.getZookeeperBrokers(), nakadiConsumerProperties.getExhibitorAddresses(),
-                nakadiConsumerProperties.getExhibitorPort());
+        return new ZKHolder(nakadiConsumerProperties.getZookeeperBrokers(),
+                nakadiConsumerProperties.getExhibitorAddresses(), nakadiConsumerProperties.getExhibitorPort());
     }
 
     @Bean
     @ConditionalOnProperty(value = "partitionCoordinatorProvider", prefix = PREFIX, havingValue = "zk-simple")
-    public ConsumerPartitionCoordinatorProvider simpleConsumerPartitionCoordinator(final ZKHolder zkHolder) {
-        return consumerName -> {
-            final ZKSimpleConsumerPartitionCoordinator coordinator = new ZKSimpleConsumerPartitionCoordinator(zkHolder, consumerName);
+    public ConsumerPartitionCoordinatorProvider simpleConsumerPartitionCoordinator(final ZKHolder zkHolder,
+            final EventErrorHandlerList eventErrorHandlerList) {
+        return
+            consumerName -> {
+            final ZKSimpleConsumerPartitionCoordinator coordinator = new ZKSimpleConsumerPartitionCoordinator(zkHolder,
+                    consumerName, eventErrorHandlerList.getEventErrorHandlerList());
             final Boolean value = nakadiConsumerProperties.getStartNewestAvailableOffset();
             if (null != value) {
                 coordinator.setStartNewestAvailableOffset(value);
             }
+
             return coordinator;
         };
     }
@@ -161,17 +204,17 @@ public class NakadiConsumerConfiguration {
     @Bean(initMethod = "init")
     @ConditionalOnProperty(value = "partitionCoordinatorProvider", prefix = PREFIX, havingValue = "zk-simple")
     public ZKHolder simpleZKHolder() {
-        return new ZKHolder(nakadiConsumerProperties.getZookeeperBrokers(), nakadiConsumerProperties.getExhibitorAddresses(),
-                nakadiConsumerProperties.getExhibitorPort());
+        return new ZKHolder(nakadiConsumerProperties.getZookeeperBrokers(),
+                nakadiConsumerProperties.getExhibitorAddresses(), nakadiConsumerProperties.getExhibitorPort());
     }
 
     @Bean
-    @ConditionalOnProperty(value = "oauth2Enabled", prefix = PREFIX, matchIfMissing = true,
-            havingValue = "true")
-    public AuthorizationValueProvider oauth2AccessTokenProvider(AccessTokens accessTokens) {
+    @ConditionalOnProperty(value = "oauth2Enabled", prefix = PREFIX, matchIfMissing = true, havingValue = "true")
+    public AuthorizationValueProvider oauth2AccessTokenProvider(final AccessTokens accessTokens) {
         final String tokenId = nakadiConsumerProperties.getNakadiTokenId();
         final AccessTokenProvider accessTokenProvider = new StupsTokensAccessTokenProvider(tokenId, accessTokens);
-        return () -> {
+        return
+            () -> {
             final String accessToken = accessTokenProvider.obtainAccessToken(null, null).getValue();
             return format("Bearer %s", accessToken);
         };

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiEventErrorHandlerConfiguration.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiEventErrorHandlerConfiguration.java
@@ -1,0 +1,39 @@
+package de.zalando.paradox.nakadi.consumer.boot;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.zalando.stups.tokens.config.AccessTokensBeanAutoConfiguration;
+
+import de.zalando.paradox.nakadi.consumer.boot.components.EventErrorHandlerList;
+import de.zalando.paradox.nakadi.consumer.core.http.handlers.EventErrorHandler;
+
+@Configuration
+@AutoConfigureAfter(AccessTokensBeanAutoConfiguration.class)
+public class NakadiEventErrorHandlerConfiguration {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Bean
+    public EventErrorHandlerList eventErrorHandlerList() {
+
+        final Map<String, EventErrorHandler> eventErrorHandlerMap = applicationContext.getBeansOfType(
+                EventErrorHandler.class);
+
+        if (null != eventErrorHandlerMap && !eventErrorHandlerMap.isEmpty()) {
+            return new EventErrorHandlerList(eventErrorHandlerMap.entrySet().stream().map(Map.Entry::getValue).collect(
+                        Collectors.toList()));
+        } else {
+            return new EventErrorHandlerList();
+        }
+    }
+}

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiEventErrorHandlerConfiguration.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiEventErrorHandlerConfiguration.java
@@ -5,19 +5,14 @@ import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import org.zalando.stups.tokens.config.AccessTokensBeanAutoConfiguration;
 
 import de.zalando.paradox.nakadi.consumer.boot.components.EventErrorHandlerList;
 import de.zalando.paradox.nakadi.consumer.core.http.handlers.EventErrorHandler;
 
 @Configuration
-@AutoConfigureAfter(AccessTokensBeanAutoConfiguration.class)
 public class NakadiEventErrorHandlerConfiguration {
 
     @Autowired

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/ReplayHandler.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/ReplayHandler.java
@@ -36,7 +36,6 @@ class ReplayHandler {
         public void error(final Throwable t, final EventTypePartition eventTypePartition, @Nullable final String cursor,
                 final String rawEvent) {
 
-            // todo should we add the handler?
             ThrowableUtils.throwException(t);
         }
     };

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/components/EventErrorHandlerList.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/components/EventErrorHandlerList.java
@@ -1,0 +1,23 @@
+package de.zalando.paradox.nakadi.consumer.boot.components;
+
+import java.util.Collections;
+import java.util.List;
+
+import de.zalando.paradox.nakadi.consumer.core.http.handlers.EventErrorHandler;
+
+public class EventErrorHandlerList {
+
+    private final List<EventErrorHandler> eventErrorHandlerList;
+
+    public EventErrorHandlerList() {
+        this(Collections.emptyList());
+    }
+
+    public EventErrorHandlerList(final List<EventErrorHandler> eventErrorHandlers) {
+        this.eventErrorHandlerList = eventErrorHandlers;
+    }
+
+    public List<EventErrorHandler> getEventErrorHandlerList() {
+        return eventErrorHandlerList;
+    }
+}

--- a/paradox-nakadi-consumer-boot/src/main/resources/META-INF/spring.factories
+++ b/paradox-nakadi-consumer-boot/src/main/resources/META-INF/spring.factories
@@ -2,4 +2,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 de.zalando.paradox.nakadi.consumer.boot.NakadiConsumerConfiguration,\
 de.zalando.paradox.nakadi.consumer.boot.EventReceiverRegistryConfiguration,\
 de.zalando.paradox.nakadi.consumer.boot.ControllerConfiguration,\
+de.zalando.paradox.nakadi.consumer.boot.NakadiEventErrorHandlerConfiguration,\
 de.zalando.paradox.nakadi.consumer.boot.ClientConfiguration

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/client/impl/ClientImpl.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/client/impl/ClientImpl.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
@@ -117,9 +116,9 @@ public class ClientImpl implements Client {
     }
 
     private String getEvent0(final String content) {
-        final Optional<NakadiEventBatch<String>> events = EventUtils.getRawEventBatch(objectMapper, content);
-        checkArgument(events.isPresent());
-        return Iterables.getOnlyElement(events.get().getEvents());
+        final NakadiEventBatch<String> events = EventUtils.getRawEventBatch(objectMapper, content);
+        checkArgument(events != null);
+        return Iterables.getOnlyElement(events.getEvents());
     }
 
     public static class Builder {

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseBulkHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseBulkHandler.java
@@ -37,26 +37,26 @@ abstract class AbstractEventsResponseBulkHandler<T> extends AbstractResponseHand
 
             final List<T> batchEvents = optionalBatch.get().getEvents();
             if (null != batchEvents && !batchEvents.isEmpty()) {
-                handleEvents(cursor, batchEvents);
+                handleEvents(cursor, batchEvents, content);
             } else {
                 try {
                     log.info("Keep alive offset [{}]", cursor.getOffset());
                     coordinator.commit(cursor);
                 } catch (Throwable t) {
                     log.error("Handler error at cursor [{}]", cursor);
-                    coordinator.error(t, eventTypePartition);
+                    coordinator.error(t, eventTypePartition, cursor.getOffset(), content);
                 }
             }
         }
     }
 
-    private void handleEvents(final EventTypeCursor cursor, final List<T> events) {
+    private void handleEvents(final EventTypeCursor cursor, final List<T> events, final String content) {
         try {
             delegate.onEvent(cursor, events);
             coordinator.commit(cursor);
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             log.error("Handler error at cursor [{}]", cursor);
-            coordinator.error(t, eventTypePartition);
+            coordinator.error(t, eventTypePartition, cursor.getOffset(), content);
         }
     }
 

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseBulkHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseBulkHandler.java
@@ -1,7 +1,6 @@
 package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -26,25 +25,20 @@ abstract class AbstractEventsResponseBulkHandler<T> extends AbstractResponseHand
     @Override
     public void onResponse(final String content) {
         final String[] events = getEvents(content);
-        for (String event : events) {
-            final Optional<NakadiEventBatch<T>> optionalBatch = getEventBatch(event);
-            if (!optionalBatch.isPresent()) {
-                return;
-            }
+        for (final String event : events) {
+            final NakadiEventBatch<T> nakadiEventBatch = getEventBatch(event);
 
-            final EventTypeCursor cursor = EventTypeCursor.of(eventTypePartition,
-                    optionalBatch.get().getCursor().getOffset());
+            if (nakadiEventBatch != null) {
 
-            final List<T> batchEvents = optionalBatch.get().getEvents();
-            if (null != batchEvents && !batchEvents.isEmpty()) {
-                handleEvents(cursor, batchEvents, content);
-            } else {
-                try {
+                final EventTypeCursor cursor = EventTypeCursor.of(eventTypePartition,
+                        nakadiEventBatch.getCursor().getOffset());
+
+                final List<T> batchEvents = nakadiEventBatch.getEvents();
+
+                if (batchEvents == null || batchEvents.isEmpty()) {
                     log.info("Keep alive offset [{}]", cursor.getOffset());
-                    coordinator.commit(cursor);
-                } catch (Throwable t) {
-                    log.error("Handler error at cursor [{}]", cursor);
-                    coordinator.error(t, eventTypePartition, cursor.getOffset(), content);
+                } else {
+                    handleEvents(cursor, batchEvents, content);
                 }
             }
         }
@@ -53,12 +47,13 @@ abstract class AbstractEventsResponseBulkHandler<T> extends AbstractResponseHand
     private void handleEvents(final EventTypeCursor cursor, final List<T> events, final String content) {
         try {
             delegate.onEvent(cursor, events);
-            coordinator.commit(cursor);
         } catch (final Throwable t) {
             log.error("Handler error at cursor [{}]", cursor);
             coordinator.error(t, eventTypePartition, cursor.getOffset(), content);
         }
+
+        coordinator.commit(cursor);
     }
 
-    abstract Optional<NakadiEventBatch<T>> getEventBatch(final String string);
+    abstract NakadiEventBatch<T> getEventBatch(final String string);
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseHandler.java
@@ -1,12 +1,8 @@
 package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
-import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
-
 import java.util.List;
-import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -18,7 +14,6 @@ import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionCoordinator;
 import de.zalando.paradox.nakadi.consumer.core.utils.LoggingUtils;
 
 abstract class AbstractEventsResponseHandler<T> extends AbstractResponseHandler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractEventsResponseHandler.class);
 
     private final EventHandler<T> delegate;
 
@@ -31,66 +26,46 @@ abstract class AbstractEventsResponseHandler<T> extends AbstractResponseHandler 
     @Override
     public void onResponse(final String content) {
         final String[] events = getEvents(content);
-        for (String event : events) {
-            final Optional<NakadiEventBatch<T>> optionalBatch = getEventBatch(event);
-            if (!optionalBatch.isPresent()) {
-                return;
-            }
+        for (final String event : events) {
 
-            final EventTypeCursor cursor = EventTypeCursor.of(eventTypePartition,
-                    optionalBatch.get().getCursor().getOffset());
+            final NakadiEventBatch<T> nakadiEventBatch = getNakadiEventBatch(event);
 
-            final List<T> batchEvents = optionalBatch.get().getEvents();
-            if (null != batchEvents && !batchEvents.isEmpty()) {
-                handleEvents(cursor, batchEvents);
-            } else {
-                try {
+            if (nakadiEventBatch != null) {
+                final EventTypeCursor cursor = EventTypeCursor.of(eventTypePartition,
+                        nakadiEventBatch.getCursor().getOffset());
+                final List<T> batchEvents = nakadiEventBatch.getEvents();
+
+                if (batchEvents == null || batchEvents.isEmpty()) {
                     log.info("Keep alive offset [{}]", cursor.getOffset());
-                    coordinator.commit(cursor);
-                } catch (Throwable t) {
-                    log.error("Handler error at cursor [{}]", cursor);
-                    coordinator.error(t, eventTypePartition);
+                } else {
+                    handleEvents(cursor, batchEvents, content);
                 }
             }
         }
     }
 
-    private void handleEvents(final EventTypeCursor cursor, final List<T> events) {
-        for (int i = 0; i < events.size(); i++) {
-            final EventTypeCursor commitCursor = decreaseCursor(cursor, events.size() - (i + 1));
-            try {
-                delegate.onEvent(commitCursor, events.get(i));
-                coordinator.commit(commitCursor);
-            } catch (Throwable t) {
-                log.error("Handler error at cursor [{}]", commitCursor);
-                coordinator.error(t, eventTypePartition);
-            }
+    @Nullable
+    private NakadiEventBatch<T> getNakadiEventBatch(final String event) {
+        try {
+            return getEventBatch(event);
+        } catch (final Throwable t) {
+            coordinator.error(t, eventTypePartition, null, event);
+            return null;
         }
     }
 
-    /**
-     * Decreases the cursor as received from Nakadi by n. This is needed because Nakadi returns a cursor that points to
-     * the end of a chunk, i.e., the last delivered event. If n is lower or equals 0, the input cursor is returned. Note
-     * that the special cursor 'BEGIN' cannot be decremented and in this case this method also returns the input cursor.
-     *
-     * @return  A new instance of {@link EventTypeCursor} with an offset decremented by n, or the same instance if the
-     *          offset cannot be decremented.
-     */
-    private EventTypeCursor decreaseCursor(final EventTypeCursor cursor, final int n) {
-        if (n > 0) {
+    private void handleEvents(final EventTypeCursor cursor, final List<T> events, final String content) {
+        for (final T event : events) {
             try {
-                final long nextOffset = Long.parseLong(cursor.getOffset()) - n;
-                return EventTypeCursor.of(cursor.getEventTypePartition(), Long.toString(nextOffset));
-            } catch (NumberFormatException ignore) {
-                LOGGER.warn("Cannot advance cursor [{}] by [{}] due to [{}]", cursor, n, getMessage(ignore));
-
-                // offset can be BEGIN
-                return cursor;
+                delegate.onEvent(cursor, event);
+            } catch (final Throwable t) {
+                log.error("Handler error at cursor [{}]", cursor);
+                coordinator.error(t, eventTypePartition, cursor.getOffset(), content);
             }
-        } else {
-            return cursor;
         }
+
+        coordinator.commit(cursor);
     }
 
-    abstract Optional<NakadiEventBatch<T>> getEventBatch(final String string);
+    abstract NakadiEventBatch<T> getEventBatch(final String string);
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractEventsResponseHandler.java
@@ -1,5 +1,7 @@
 package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -28,18 +30,17 @@ abstract class AbstractEventsResponseHandler<T> extends AbstractResponseHandler 
         final String[] events = getEvents(content);
         for (final String event : events) {
 
-            final NakadiEventBatch<T> nakadiEventBatch = getNakadiEventBatch(event);
+            final NakadiEventBatch<T> nakadiEventBatch = requireNonNull(getNakadiEventBatch(event),
+                    "Nakadi event batch must not be null!");
 
-            if (nakadiEventBatch != null) {
-                final EventTypeCursor cursor = EventTypeCursor.of(eventTypePartition,
-                        nakadiEventBatch.getCursor().getOffset());
-                final List<T> batchEvents = nakadiEventBatch.getEvents();
+            final EventTypeCursor cursor = EventTypeCursor.of(eventTypePartition,
+                    nakadiEventBatch.getCursor().getOffset());
+            final List<T> batchEvents = nakadiEventBatch.getEvents();
 
-                if (batchEvents == null || batchEvents.isEmpty()) {
-                    log.info("Keep alive offset [{}]", cursor.getOffset());
-                } else {
-                    handleEvents(cursor, batchEvents, content);
-                }
+            if (batchEvents == null || batchEvents.isEmpty()) {
+                log.info("Keep alive offset [{}]", cursor.getOffset());
+            } else {
+                handleEvents(cursor, batchEvents, content);
             }
         }
     }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/AbstractResponseHandler.java
@@ -2,8 +2,6 @@ package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
 import java.io.IOException;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiEventCursor;
 import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionCoordinator;
+import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
 abstract class AbstractResponseHandler implements ResponseHandler {
 
@@ -32,12 +31,13 @@ abstract class AbstractResponseHandler implements ResponseHandler {
         return string.split(BATCH_SEPARATOR);
     }
 
-    Optional<NakadiEventCursor> getEventCursor(final String string) {
+    NakadiEventCursor getEventCursor(final String string) {
         try {
-            return Optional.of(jsonMapper.readValue(string, NakadiEventCursor.class));
+            return jsonMapper.readValue(string, NakadiEventCursor.class);
         } catch (IOException e) {
             log.error("Error while parsing event cursor from [{}]", string, e);
-            return Optional.empty();
+            ThrowableUtils.throwException(e);
+            return null;
         }
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/BatchEventsResponseBulkHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/BatchEventsResponseBulkHandler.java
@@ -2,14 +2,13 @@ package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
 import java.io.IOException;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiEventBatch;
 import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionCoordinator;
+import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
 public class BatchEventsResponseBulkHandler<T> extends AbstractEventsResponseBulkHandler<T> {
     private final JavaType javaType;
@@ -21,12 +20,13 @@ public class BatchEventsResponseBulkHandler<T> extends AbstractEventsResponseBul
     }
 
     @Override
-    Optional<NakadiEventBatch<T>> getEventBatch(final String string) {
+    NakadiEventBatch<T> getEventBatch(final String string) {
         try {
-            return Optional.of(jsonMapper.readValue(string, javaType));
-        } catch (IOException e) {
+            return jsonMapper.readValue(string, javaType);
+        } catch (final IOException e) {
             log.error("Error while parsing event batch from [{}]", string, e);
-            return Optional.empty();
+            ThrowableUtils.throwException(e);
+            return null;
         }
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/BatchEventsResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/BatchEventsResponseHandler.java
@@ -2,14 +2,13 @@ package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
 import java.io.IOException;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiEventBatch;
 import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionCoordinator;
+import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
 public class BatchEventsResponseHandler<T> extends AbstractEventsResponseHandler<T> {
     private final JavaType javaType;
@@ -21,12 +20,12 @@ public class BatchEventsResponseHandler<T> extends AbstractEventsResponseHandler
     }
 
     @Override
-    Optional<NakadiEventBatch<T>> getEventBatch(final String string) {
+    NakadiEventBatch<T> getEventBatch(final String string) {
         try {
-            return Optional.of(jsonMapper.readValue(string, javaType));
-        } catch (IOException e) {
-            log.error("Error while parsing event batch from [{}]", string, e);
-            return Optional.empty();
+            return jsonMapper.readValue(string, javaType);
+        } catch (final IOException e) {
+            ThrowableUtils.throwException(e);
+            return null;
         }
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/EventErrorHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/EventErrorHandler.java
@@ -1,0 +1,10 @@
+package de.zalando.paradox.nakadi.consumer.core.http.handlers;
+
+import javax.annotation.Nullable;
+
+import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
+
+public interface EventErrorHandler {
+
+    void onError(Throwable t, EventTypePartition eventTypePartition, @Nullable String offset, String rawEvent);
+}

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/EventErrorHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/EventErrorHandler.java
@@ -4,6 +4,7 @@ import javax.annotation.Nullable;
 
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 
+@FunctionalInterface
 public interface EventErrorHandler {
 
     void onError(Throwable t, EventTypePartition eventTypePartition, @Nullable String offset, String rawEvent);

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/EventUtils.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/EventUtils.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -30,8 +29,7 @@ public class EventUtils {
 
     private EventUtils() { }
 
-    public static Optional<NakadiEventBatch<String>> getRawEventBatch(final ObjectMapper jsonMapper,
-            final String string) {
+    public static NakadiEventBatch<String> getRawEventBatch(final ObjectMapper jsonMapper, final String string) {
         try {
             final EventReader reader = new EventReader(jsonMapper, string).invoke();
             final JsonNode eventsNode = reader.getEventsNode();
@@ -60,16 +58,15 @@ public class EventUtils {
                 rawEvents = Collections.emptyList();
             }
 
-            return Optional.of(new NakadiEventBatch<>(new NakadiCursor(reader.getPartition(), reader.getOffset()),
-                        rawEvents));
+            return new NakadiEventBatch<>(new NakadiCursor(reader.getPartition(), reader.getOffset()), rawEvents);
         } catch (IOException e) {
             LOGGER.error("Error while parsing event batch from [{}]", string, e);
-            return Optional.empty();
+            ThrowableUtils.throwException(e);
+            return null;
         }
     }
 
-    public static Optional<NakadiEventBatch<JsonNode>> getJsonEventBatch(final ObjectMapper jsonMapper,
-            final String string) {
+    public static NakadiEventBatch<JsonNode> getJsonEventBatch(final ObjectMapper jsonMapper, final String string) {
         try {
             final EventReader reader = new EventReader(jsonMapper, string).invoke();
             final JsonNode eventsNode = reader.getEventsNode();
@@ -88,11 +85,11 @@ public class EventUtils {
                 jsonEvents = Collections.emptyList();
             }
 
-            return Optional.of(new NakadiEventBatch<>(new NakadiCursor(reader.getPartition(), reader.getOffset()),
-                        jsonEvents));
+            return new NakadiEventBatch<>(new NakadiCursor(reader.getPartition(), reader.getOffset()), jsonEvents);
         } catch (IOException e) {
             LOGGER.error("Error while parsing event json from [{}]", string, e);
-            return Optional.empty();
+            ThrowableUtils.throwException(e);
+            return null;
         }
     }
 

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/JsonEventResponseBulkHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/JsonEventResponseBulkHandler.java
@@ -1,7 +1,5 @@
 package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -17,7 +15,7 @@ public class JsonEventResponseBulkHandler extends AbstractEventsResponseBulkHand
     }
 
     @Override
-    Optional<NakadiEventBatch<JsonNode>> getEventBatch(final String string) {
+    NakadiEventBatch<JsonNode> getEventBatch(final String string) {
         return EventUtils.getJsonEventBatch(jsonMapper, string);
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/JsonEventResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/JsonEventResponseHandler.java
@@ -16,6 +16,6 @@ public class JsonEventResponseHandler extends AbstractEventsResponseHandler<Json
 
     @Override
     NakadiEventBatch<JsonNode> getEventBatch(final String string) {
-        return EventUtils.getJsonEventBatch(jsonMapper, string).orElseThrow(IllegalStateException::new);
+        return EventUtils.getJsonEventBatch(jsonMapper, string);
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/JsonEventResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/JsonEventResponseHandler.java
@@ -1,7 +1,5 @@
 package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -17,7 +15,7 @@ public class JsonEventResponseHandler extends AbstractEventsResponseHandler<Json
     }
 
     @Override
-    Optional<NakadiEventBatch<JsonNode>> getEventBatch(final String string) {
-        return EventUtils.getJsonEventBatch(jsonMapper, string);
+    NakadiEventBatch<JsonNode> getEventBatch(final String string) {
+        return EventUtils.getJsonEventBatch(jsonMapper, string).orElseThrow(IllegalStateException::new);
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawContentResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawContentResponseHandler.java
@@ -53,7 +53,7 @@ public class RawContentResponseHandler extends AbstractResponseHandler {
                 coordinator.commit(lastCursor);
             } catch (Throwable t) {
                 LOGGER.error("Handler error at firstCursor [{}] , lastCursor [{}]", firstCursor, lastCursor);
-                coordinator.error(t, eventTypePartition);
+                coordinator.error(t, eventTypePartition, lastCursor.getOffset(), content);
             }
         }
     }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawEventResponseBulkHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawEventResponseBulkHandler.java
@@ -1,7 +1,5 @@
 package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
@@ -16,7 +14,7 @@ public class RawEventResponseBulkHandler extends AbstractEventsResponseBulkHandl
     }
 
     @Override
-    Optional<NakadiEventBatch<String>> getEventBatch(final String string) {
+    NakadiEventBatch<String> getEventBatch(final String string) {
         return EventUtils.getRawEventBatch(jsonMapper, string);
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawEventResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawEventResponseHandler.java
@@ -15,6 +15,6 @@ public class RawEventResponseHandler extends AbstractEventsResponseHandler<Strin
 
     @Override
     NakadiEventBatch<String> getEventBatch(final String string) {
-        return EventUtils.getRawEventBatch(jsonMapper, string).orElseThrow(IllegalArgumentException::new);
+        return EventUtils.getRawEventBatch(jsonMapper, string);
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawEventResponseHandler.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/handlers/RawEventResponseHandler.java
@@ -1,7 +1,5 @@
 package de.zalando.paradox.nakadi.consumer.core.http.handlers;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
@@ -16,7 +14,7 @@ public class RawEventResponseHandler extends AbstractEventsResponseHandler<Strin
     }
 
     @Override
-    Optional<NakadiEventBatch<String>> getEventBatch(final String string) {
-        return EventUtils.getRawEventBatch(jsonMapper, string);
+    NakadiEventBatch<String> getEventBatch(final String string) {
+        return EventUtils.getRawEventBatch(jsonMapper, string).orElseThrow(IllegalArgumentException::new);
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/PartitionOffsetManagement.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/PartitionOffsetManagement.java
@@ -1,5 +1,7 @@
 package de.zalando.paradox.nakadi.consumer.core.partitioned;
 
+import javax.annotation.Nullable;
+
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 
@@ -8,7 +10,7 @@ public interface PartitionOffsetManagement {
 
     void flush(final EventTypePartition eventTypePartition);
 
-    void error(final Throwable t, final EventTypePartition eventTypePartition);
+    void error(Throwable t, EventTypePartition eventTypePartition, @Nullable String offset, String rawEvent);
 
     void error(final int statusCode, final String content, final EventTypePartition eventTypePartition);
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/EmptyPartitionCoordinator.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/EmptyPartitionCoordinator.java
@@ -2,6 +2,8 @@ package de.zalando.paradox.nakadi.consumer.core.partitioned.impl;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 import de.zalando.paradox.nakadi.consumer.core.domain.EventType;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
@@ -36,7 +38,8 @@ public class EmptyPartitionCoordinator implements PartitionCoordinator {
     public void flush(final EventTypePartition eventTypePartition) { }
 
     @Override
-    public void error(final Throwable t, final EventTypePartition eventTypePartition) { }
+    public void error(final Throwable t, final EventTypePartition eventTypePartition, @Nullable final String cursor,
+            final String rowEvent) { }
 
     @Override
     public void error(final int statusCode, final String content, final EventTypePartition eventTypePartition) { }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
@@ -26,8 +26,7 @@ public class SimplePartitionCoordinator extends AbstractPartitionCoordinator {
     private final List<EventErrorHandler> eventErrorHandlerList;
 
     public SimplePartitionCoordinator() {
-        super(LoggerFactory.getLogger(SimplePartitionCoordinator.class));
-        eventErrorHandlerList = Collections.emptyList();
+        this(Collections.emptyList());
     }
 
     public SimplePartitionCoordinator(final List<EventErrorHandler> eventErrorHandlers) {

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
@@ -3,6 +3,8 @@ package de.zalando.paradox.nakadi.consumer.core.partitioned.impl;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -13,6 +15,7 @@ import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartitions;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiPartition;
+import de.zalando.paradox.nakadi.consumer.core.http.handlers.EventErrorHandler;
 import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionCommitCallback;
 import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
@@ -20,9 +23,16 @@ public class SimplePartitionCoordinator extends AbstractPartitionCoordinator {
 
     private final AtomicBoolean running = new AtomicBoolean(true);
     private boolean startNewestAvailableOffset = true;
+    private final List<EventErrorHandler> eventErrorHandlerList;
 
     public SimplePartitionCoordinator() {
         super(LoggerFactory.getLogger(SimplePartitionCoordinator.class));
+        eventErrorHandlerList = Collections.emptyList();
+    }
+
+    public SimplePartitionCoordinator(final List<EventErrorHandler> eventErrorHandlers) {
+        super(LoggerFactory.getLogger(SimplePartitionCoordinator.class));
+        this.eventErrorHandlerList = eventErrorHandlers;
     }
 
     @Override
@@ -90,13 +100,17 @@ public class SimplePartitionCoordinator extends AbstractPartitionCoordinator {
     }
 
     @Override
-    public void error(final Throwable t, final EventTypePartition eventTypePartition) {
+    public void error(final Throwable t, final EventTypePartition eventTypePartition, final String cursor,
+            final String rawEvent) {
 
         // it will unsubscribe reactive receiver
         if (ThrowableUtils.isUnrecoverableException(t)) {
             log.error("Error [{}] reason [{}]", eventTypePartition, getMessage(t));
             ThrowableUtils.throwException(t);
         } else {
+
+            eventErrorHandlerList.forEach(eventErrorHandler ->
+                    eventErrorHandler.onError(t, eventTypePartition, cursor, rawEvent));
             log.error("Error [{}] reason [{}]", eventTypePartition, getMessage(t), t);
         }
     }

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagement.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagement.java
@@ -7,6 +7,7 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
@@ -34,10 +35,10 @@ class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
     private final ZKConsumerOffset consumerOffset;
     private final List<EventErrorHandler> eventErrorHandlers;
 
-    ZKConsumerSyncOffsetManagement(final ZKConsumerOffset consumerOffset,
-            final PartitionCommitCallbackProvider commitCallbackProvider,
-            final PartitionRebalanceListenerProvider rebalanceListenerProvider,
-            final List<EventErrorHandler> eventErrorHandlers) {
+    ZKConsumerSyncOffsetManagement(@Nonnull final ZKConsumerOffset consumerOffset,
+            @Nonnull final PartitionCommitCallbackProvider commitCallbackProvider,
+            @Nonnull final PartitionRebalanceListenerProvider rebalanceListenerProvider,
+            @Nonnull final List<EventErrorHandler> eventErrorHandlers) {
         this.commitCallbackProvider = commitCallbackProvider;
         this.rebalanceListenerProvider = rebalanceListenerProvider;
         this.consumerOffset = consumerOffset;

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagement.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagement.java
@@ -79,7 +79,7 @@ class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
             eventErrorHandlers.forEach(eventErrorHandler ->
                     eventErrorHandler.onError(t, eventTypePartition, offset, rawEvent));
 
-            LOGGER.error("Error [{}] reason [{}] raw event [{}] ", eventTypePartition, getMessage(t), t, rawEvent);
+            LOGGER.error("Error [{}] reason [{}] raw event [{}] ", eventTypePartition, getMessage(t), rawEvent, t);
         }
     }
 

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinator.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinator.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,6 +22,7 @@ import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartitions;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiPartition;
+import de.zalando.paradox.nakadi.consumer.core.http.handlers.EventErrorHandler;
 import de.zalando.paradox.nakadi.consumer.core.utils.LoggingUtils;
 import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
@@ -87,8 +89,10 @@ public class ZKLeaderConsumerPartitionCoordinator extends AbstractZKConsumerPart
         };
     }
 
-    public ZKLeaderConsumerPartitionCoordinator(final ZKHolder zkHolder, final String consumerName) {
-        super(LoggingUtils.getLogger(ZKLeaderConsumerPartitionCoordinator.class, consumerName), zkHolder, consumerName);
+    public ZKLeaderConsumerPartitionCoordinator(final ZKHolder zkHolder, final String consumerName,
+            final List<EventErrorHandler> eventErrorHandlers) {
+        super(LoggingUtils.getLogger(ZKLeaderConsumerPartitionCoordinator.class, consumerName), zkHolder, consumerName,
+            eventErrorHandlers);
         this.member = ZKMember.of(UUID.randomUUID().toString());
         this.consumerGroupMember = new ZKConsumerGroupMember(zkHolder, consumerName, member);
         this.rebalancer = new ZKLeaderConsumerPartitionRebalanceStrategy(member);
@@ -98,8 +102,9 @@ public class ZKLeaderConsumerPartitionCoordinator extends AbstractZKConsumerPart
     @VisibleForTesting
     ZKLeaderConsumerPartitionCoordinator(final ZKHolder zkHolder, final String consumerName, final ZKMember member,
             final ZKConsumerGroupMember consumerGroupMember, final ConsumerPartitionRebalanceStrategy rebalancer,
-            final ZKConsumerPartitionLeader consumerPartitionLeader) {
-        super(LoggingUtils.getLogger(ZKLeaderConsumerPartitionCoordinator.class, consumerName), zkHolder, consumerName);
+            final ZKConsumerPartitionLeader consumerPartitionLeader, final List<EventErrorHandler> eventErrorHandlers) {
+        super(LoggingUtils.getLogger(ZKLeaderConsumerPartitionCoordinator.class, consumerName), zkHolder, consumerName,
+            eventErrorHandlers);
         this.member = requireNonNull(member);
         this.consumerGroupMember = requireNonNull(consumerGroupMember);
         this.rebalancer = requireNonNull(rebalancer);

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKSimpleConsumerPartitionCoordinator.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKSimpleConsumerPartitionCoordinator.java
@@ -1,18 +1,22 @@
 package de.zalando.paradox.nakadi.consumer.partitioned.zk;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartitions;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiPartition;
+import de.zalando.paradox.nakadi.consumer.core.http.handlers.EventErrorHandler;
 import de.zalando.paradox.nakadi.consumer.core.utils.LoggingUtils;
 
 public class ZKSimpleConsumerPartitionCoordinator extends AbstractZKConsumerPartitionCoordinator {
 
     private final AtomicBoolean running = new AtomicBoolean(true);
 
-    public ZKSimpleConsumerPartitionCoordinator(final ZKHolder zkHolder, final String consumerName) {
-        super(LoggingUtils.getLogger(ZKLeaderConsumerPartitionCoordinator.class, consumerName), zkHolder, consumerName);
+    public ZKSimpleConsumerPartitionCoordinator(final ZKHolder zkHolder, final String consumerName,
+            final List<EventErrorHandler> eventErrorHandlerList) {
+        super(LoggingUtils.getLogger(ZKLeaderConsumerPartitionCoordinator.class, consumerName), zkHolder, consumerName,
+            eventErrorHandlerList);
     }
 
     @Override

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementTest.java
@@ -1,0 +1,40 @@
+package de.zalando.paradox.nakadi.consumer.partitioned.zk;
+
+import java.util.Collections;
+
+import org.assertj.core.api.Assertions;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
+import de.zalando.paradox.nakadi.consumer.core.exceptions.UnrecoverableException;
+import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionCommitCallbackProvider;
+import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionRebalanceListenerProvider;
+
+public class ZKConsumerSyncOffsetManagementTest {
+
+    @Test
+    public void testShouldNotThrowExceptionWhenThereIsNoHandler() {
+
+        final ZKConsumerSyncOffsetManagement zkConsumerSyncOffsetManagement = new ZKConsumerSyncOffsetManagement(Mockito
+                    .mock(ZKConsumerOffset.class), Mockito.mock(PartitionCommitCallbackProvider.class),
+                Mockito.mock(PartitionRebalanceListenerProvider.class), Collections.emptyList());
+
+        zkConsumerSyncOffsetManagement.error(new IllegalStateException(), Mockito.mock(EventTypePartition.class),
+            "2324", "event");
+    }
+
+    @Test
+    public void testShouldThrowExceptionWhenItGetsTheUnrecoverableException() {
+        final ZKConsumerSyncOffsetManagement zkConsumerSyncOffsetManagement = new ZKConsumerSyncOffsetManagement(Mockito
+                    .mock(ZKConsumerOffset.class), Mockito.mock(PartitionCommitCallbackProvider.class),
+                Mockito.mock(PartitionRebalanceListenerProvider.class), Collections.emptyList());
+
+        Assertions.assertThatThrownBy(() ->
+                          zkConsumerSyncOffsetManagement.error(new UnrecoverableException(),
+                              Mockito.mock(EventTypePartition.class), "2324", "event")).isInstanceOf(
+                      UnrecoverableException.class);
+    }
+}

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementTest.java
@@ -59,6 +59,6 @@ public class ZKConsumerSyncOffsetManagementTest {
         zKConsumerSyncOffsetManagement.error(new RuntimeException(), eventTypePartition, "2324", "event");
 
         Mockito.verify(eventErrorHandler).onError(Mockito.any(Throwable.class), Mockito.any(EventTypePartition.class),
-            eq("2324"), Mockito.anyString());
+            eq("2324"), eq("event"));
     }
 }

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementTest.java
@@ -1,12 +1,17 @@
 package de.zalando.paradox.nakadi.consumer.partitioned.zk;
 
+import static org.mockito.Matchers.eq;
+
 import java.util.Collections;
 
 import org.assertj.core.api.Assertions;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 import de.zalando.paradox.nakadi.consumer.core.exceptions.UnrecoverableException;
@@ -16,40 +21,44 @@ import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionRebalanceLis
 
 public class ZKConsumerSyncOffsetManagementTest {
 
-    @Test
-    public void testShouldNotThrowExceptionWhenThereIsNoHandler() {
+    private ZKConsumerSyncOffsetManagement zKConsumerSyncOffsetManagement;
 
-        new ZKConsumerSyncOffsetManagement(Mockito.mock(ZKConsumerOffset.class),
-            Mockito.mock(PartitionCommitCallbackProvider.class), Mockito.mock(PartitionRebalanceListenerProvider.class),
-            Collections.emptyList()).error(new IllegalStateException(), Mockito.mock(EventTypePartition.class), "2324",
-            "event");
+    @Mock
+    private PartitionCommitCallbackProvider partitionCommitCallbackProvider;
+
+    @Mock
+    private ZKConsumerOffset zkConsumerOffset;
+
+    @Mock
+    private PartitionRebalanceListenerProvider partitionRebalanceListenerProvider;
+
+    @Mock
+    private EventErrorHandler eventErrorHandler;
+
+    @Mock
+    private EventTypePartition eventTypePartition;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        zKConsumerSyncOffsetManagement = new ZKConsumerSyncOffsetManagement(zkConsumerOffset,
+                partitionCommitCallbackProvider, partitionRebalanceListenerProvider,
+                Collections.singletonList(eventErrorHandler));
     }
 
     @Test
     public void testShouldThrowExceptionWhenItGetsTheUnrecoverableException() {
-        final ZKConsumerSyncOffsetManagement zkConsumerSyncOffsetManagement = new ZKConsumerSyncOffsetManagement(Mockito
-                    .mock(ZKConsumerOffset.class), Mockito.mock(PartitionCommitCallbackProvider.class),
-                Mockito.mock(PartitionRebalanceListenerProvider.class), Collections.emptyList());
-
         Assertions.assertThatThrownBy(() ->
-                          zkConsumerSyncOffsetManagement.error(new UnrecoverableException(),
-                              Mockito.mock(EventTypePartition.class), "2324", "event")).isInstanceOf(
-                      UnrecoverableException.class);
+                          zKConsumerSyncOffsetManagement.error(new UnrecoverableException(), eventTypePartition, "2324",
+                              "event")).isInstanceOf(UnrecoverableException.class);
     }
 
     @Test
     public void testShouldLogTheExceptionWithHandler() {
 
-        final EventErrorHandler spy = Mockito.spy(EventErrorHandler.class);
+        zKConsumerSyncOffsetManagement.error(new RuntimeException(), eventTypePartition, "2324", "event");
 
-        final ZKConsumerSyncOffsetManagement zkConsumerSyncOffsetManagement = new ZKConsumerSyncOffsetManagement(Mockito
-                    .mock(ZKConsumerOffset.class), Mockito.mock(PartitionCommitCallbackProvider.class),
-                Mockito.mock(PartitionRebalanceListenerProvider.class), Collections.singletonList(spy));
-
-        zkConsumerSyncOffsetManagement.error(new RuntimeException(), Mockito.mock(EventTypePartition.class), "2324",
-            "event");
-
-        Mockito.verify(spy).onError(Mockito.any(Throwable.class), Mockito.any(EventTypePartition.class),
-            Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(eventErrorHandler).onError(Mockito.any(Throwable.class), Mockito.any(EventTypePartition.class),
+            eq("2324"), Mockito.anyString());
     }
 }

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinatorTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinatorTest.java
@@ -124,6 +124,6 @@ public class ZKLeaderConsumerPartitionCoordinatorTest extends AbstractZKTest {
 
         return new ZKLeaderConsumerPartitionCoordinator(zkHolder, consumerName, member, consumerGroupMember,
                 new DelegatingConsumerPartitionRebalanceStrategy(rebalancer, mockRebalancer, rebalancerMock),
-                consumerPartitionLeader);
+                consumerPartitionLeader, Collections.emptyList());
     }
 }

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderHttpEventReceiverTestConsumer.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderHttpEventReceiverTestConsumer.java
@@ -1,5 +1,7 @@
 package de.zalando.paradox.nakadi.consumer.partitioned.zk;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +25,8 @@ public class ZKLeaderHttpEventReceiverTestConsumer {
         final ZKHolder zkHolder = new ZKHolder("localhost:2181", null, null);
         zkHolder.init();
 
-        final PartitionCoordinator coordinator = new ZKLeaderConsumerPartitionCoordinator(zkHolder, consumerName);
+        final PartitionCoordinator coordinator = new ZKLeaderConsumerPartitionCoordinator(zkHolder, consumerName,
+                Collections.emptyList());
         coordinator.init();
 
         try {


### PR DESCRIPTION
The clients can use their own handlers as many as they want.

They should just implement the EventErrorHandler interface.

By default, there is no handler.