### PR TITLE
#7 Expose deleteUnavailableCursors flag to NakadiConsumerConfiguration

### DIFF
--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/EventReceiverRegistryConfiguration.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/EventReceiverRegistryConfiguration.java
@@ -99,10 +99,6 @@ public class EventReceiverRegistryConfiguration {
         return nakadiConsumerProperties.getEventsBatchLimit();
     }
 
-    public Boolean getStartNewestAvailableOffset() {
-        return nakadiConsumerProperties.getStartNewestAvailableOffset();
-    }
-
     @Bean
     public EventReceiverRegistry eventReceiverRegistry(final EventReceiverRegistryConfiguration eventReceiverConfig) {
         return new EventReceiverRegistry(eventReceiverConfig, objectMapper);

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiConsumerConfiguration.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiConsumerConfiguration.java
@@ -149,12 +149,9 @@ public class NakadiConsumerConfiguration {
             consumerName -> {
             final SimplePartitionCoordinator coordinator = new SimplePartitionCoordinator(
                     eventErrorHandlerList.getEventErrorHandlerList());
-            final Boolean value = nakadiConsumerProperties.getStartNewestAvailableOffset();
-            if (null != value) {
 
-                // use false only for development as messages will be replayed on each restart
-                coordinator.setStartNewestAvailableOffset(value);
-            }
+            // use false only for development as messages will be replayed on each restart
+            coordinator.setStartNewestAvailableOffset(nakadiConsumerProperties.isStartNewestAvailableOffset());
 
             return coordinator;
         };
@@ -168,10 +165,9 @@ public class NakadiConsumerConfiguration {
             consumerName -> {
             final ZKLeaderConsumerPartitionCoordinator coordinator = new ZKLeaderConsumerPartitionCoordinator(zkHolder,
                     consumerName, eventErrorHandlerList.getEventErrorHandlerList());
-            final Boolean value = nakadiConsumerProperties.getStartNewestAvailableOffset();
-            if (null != value) {
-                coordinator.setStartNewestAvailableOffset(value);
-            }
+
+            coordinator.setStartNewestAvailableOffset(nakadiConsumerProperties.isStartNewestAvailableOffset());
+            coordinator.setDeleteUnavailableCursors(nakadiConsumerProperties.isDeleteUnavailableCursors());
 
             return coordinator;
         };
@@ -192,10 +188,9 @@ public class NakadiConsumerConfiguration {
             consumerName -> {
             final ZKSimpleConsumerPartitionCoordinator coordinator = new ZKSimpleConsumerPartitionCoordinator(zkHolder,
                     consumerName, eventErrorHandlerList.getEventErrorHandlerList());
-            final Boolean value = nakadiConsumerProperties.getStartNewestAvailableOffset();
-            if (null != value) {
-                coordinator.setStartNewestAvailableOffset(value);
-            }
+
+            coordinator.setStartNewestAvailableOffset(nakadiConsumerProperties.isStartNewestAvailableOffset());
+            coordinator.setDeleteUnavailableCursors(nakadiConsumerProperties.isDeleteUnavailableCursors());
 
             return coordinator;
         };

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiConsumerProperties.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/NakadiConsumerProperties.java
@@ -44,7 +44,9 @@ public class NakadiConsumerProperties {
 
     private Integer eventsBatchLimit;
 
-    private Boolean startNewestAvailableOffset;
+    private boolean startNewestAvailableOffset = true;
+
+    private boolean deleteUnavailableCursors;
 
     private boolean eventTypePartitionCoordinator = true;
 
@@ -184,12 +186,20 @@ public class NakadiConsumerProperties {
         this.eventsBatchLimit = eventsBatchLimit;
     }
 
-    public Boolean getStartNewestAvailableOffset() {
+    public boolean isStartNewestAvailableOffset() {
         return startNewestAvailableOffset;
     }
 
-    public void setStartNewestAvailableOffset(final Boolean startNewestAvailableOffset) {
+    public void setStartNewestAvailableOffset(final boolean startNewestAvailableOffset) {
         this.startNewestAvailableOffset = startNewestAvailableOffset;
+    }
+
+    public boolean isDeleteUnavailableCursors() {
+        return deleteUnavailableCursors;
+    }
+
+    public void setDeleteUnavailableCursors(final boolean deleteUnavailableCursors) {
+        this.deleteUnavailableCursors = deleteUnavailableCursors;
     }
 
     public Long getPartitionsRetryRandomMillis() {

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/PartitionRebalanceListenerProvider.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/PartitionRebalanceListenerProvider.java
@@ -1,8 +1,13 @@
 package de.zalando.paradox.nakadi.consumer.core.partitioned;
 
+import javax.annotation.Nullable;
+
 import de.zalando.paradox.nakadi.consumer.core.domain.EventType;
 
 @FunctionalInterface
 public interface PartitionRebalanceListenerProvider {
+
+    @Nullable
     PartitionRebalanceListener getPartitionRebalanceListener(final EventType eventType);
+
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/partitioned/impl/SimplePartitionCoordinator.java
@@ -22,7 +22,9 @@ import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 public class SimplePartitionCoordinator extends AbstractPartitionCoordinator {
 
     private final AtomicBoolean running = new AtomicBoolean(true);
+
     private boolean startNewestAvailableOffset = true;
+
     private final List<EventErrorHandler> eventErrorHandlerList;
 
     public SimplePartitionCoordinator() {

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/AbstractZKConsumerPartitionCoordinator.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/AbstractZKConsumerPartitionCoordinator.java
@@ -8,23 +8,27 @@ import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 
+import com.google.common.base.MoreObjects;
+
 import de.zalando.paradox.nakadi.consumer.core.domain.EventType;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiPartition;
 import de.zalando.paradox.nakadi.consumer.core.http.handlers.EventErrorHandler;
 import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionAdminService;
-import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionOffsetManagement;
 import de.zalando.paradox.nakadi.consumer.core.partitioned.impl.AbstractPartitionCoordinator;
 import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
 abstract class AbstractZKConsumerPartitionCoordinator extends AbstractPartitionCoordinator {
 
-    private boolean startNewestAvailableOffset = true;
+    private volatile boolean startNewestAvailableOffset = true;
 
     private final String consumerName;
-    private final PartitionOffsetManagement offsetManagement;
+
+    private final ZKConsumerSyncOffsetManagement offsetManagement;
+
     private final ZKConsumerOffset consumerOffset;
+
     private final ZKAdminService adminService;
 
     AbstractZKConsumerPartitionCoordinator(final Logger log, final ZKHolder zkHolder, final String consumerName,
@@ -77,68 +81,20 @@ abstract class AbstractZKConsumerPartitionCoordinator extends AbstractPartitionC
     }
 
     private String nextOffset(final EventType eventType, final NakadiPartition nakadiPartition) throws Exception {
-        String result = startNewestAvailableOffset ? nakadiPartition.getNewestAvailableOffset() : "BEGIN";
+        final String newestOrOldestAvailableOffset = startNewestAvailableOffset
+            ? nakadiPartition.getNewestAvailableOffset() : "BEGIN";
 
-        final String path = consumerOffset.getOffsetPath(eventType.getName(), nakadiPartition.getPartition());
-        final String zkOffset = consumerOffset.getOffset(path);
-        if (null != zkOffset) {
-            final long offsetValue;
-            try {
-                offsetValue = Long.parseLong(zkOffset);
-            } catch (NumberFormatException e) {
-                log.warn("Cannot convert ZK offset [{}] from path [{}] to long", zkOffset, path);
-                return result;
-            }
+        final String zkOffset = consumerOffset.getOffset(eventType, nakadiPartition.getPartition());
 
-            final long newestValue;
-            try {
-                newestValue = Long.parseLong(nakadiPartition.getNewestAvailableOffset());
-            } catch (NumberFormatException e) {
-                log.warn("Cannot convert Nakadi newest offset [{}] for event type [{}] , partition [{}] to long",
-                    nakadiPartition.getNewestAvailableOffset(), eventType, nakadiPartition.getPartition());
-                return result;
-            }
-
-            long oldestValue = Long.MIN_VALUE;
-            try {
-                oldestValue = Long.parseLong(nakadiPartition.getOldestAvailableOffset());
-            } catch (NumberFormatException ignore) {
-
-                // ok when the value is BEGIN
-                log.info("Cannot convert Nakadi oldest offset [{}] for event type [{}] , partition [{}] to long",
-                    nakadiPartition.getOldestAvailableOffset(), eventType, nakadiPartition.getPartition());
-            }
-
-            // [[{"oldest_available_offset":"1522","newest_available_offset":"1521","partition":"0"}]]
-            if (oldestValue > newestValue) {
-
-                // messages purged due to retention time
-                log.warn("Oldest offset [{}] greater than newest offset [{}]", oldestValue, newestValue);
-                oldestValue = newestValue;
-            }
-
-            final long offset;
-            if (oldestValue > offsetValue) {
-                log.error("Inconsistent ZK data for [{}]. ZK offset [{}] is less than Nakadi oldest offset [{}]", path,
-                    offsetValue, oldestValue);
-                offset = oldestValue;
-            } else if (offsetValue > newestValue) {
-                log.error("Inconsistent ZK data for [{}]. ZK offset [{}] is greater than Nakadi newest offset [{}]",
-                    path, offsetValue, oldestValue);
-                offset = newestValue;
-            } else {
-                offset = offsetValue;
-            }
-
-            result = Long.toString(offset);
-
-        }
-
-        return result;
+        return MoreObjects.firstNonNull(zkOffset, newestOrOldestAvailableOffset);
     }
 
     public void setStartNewestAvailableOffset(final boolean startNewestAvailableOffset) {
         this.startNewestAvailableOffset = startNewestAvailableOffset;
+    }
+
+    public void setDeleteUnavailableCursors(final boolean deleteUnavailableCursors) {
+        this.offsetManagement.setDeleteUnavailableCursors(deleteUnavailableCursors);
     }
 
     public String getConsumerName() {
@@ -149,4 +105,5 @@ abstract class AbstractZKConsumerPartitionCoordinator extends AbstractPartitionC
     public Optional<PartitionAdminService> getAdminService() {
         return Optional.of(adminService);
     }
+
 }

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagement.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagement.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -24,15 +25,22 @@ import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionRebalanceLis
 import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
 class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
-    private static final String CURSORS_ARE_NOT_VALID = "cursors are not valid";
+
+    private static final Pattern CURSOR_NOT_AVAILABLE = Pattern.compile(
+            "offset \\S+ for partition \\S+ is unavailable");
+
+    private static final int PRECONDITION_FAILED_HTTP_CODE = 412;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZKConsumerSyncOffsetManagement.class);
 
-    private boolean resetStorageOnInvalidCursor = false;
+    private volatile boolean deleteUnavailableCursors;
 
     private final PartitionCommitCallbackProvider commitCallbackProvider;
+
     private final PartitionRebalanceListenerProvider rebalanceListenerProvider;
+
     private final ZKConsumerOffset consumerOffset;
+
     private final List<EventErrorHandler> eventErrorHandlers;
 
     ZKConsumerSyncOffsetManagement(@Nonnull final ZKConsumerOffset consumerOffset,
@@ -47,7 +55,7 @@ class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
 
     @Override
     public void commit(final EventTypeCursor cursor) {
-        LOGGER.debug("Commit {} ", cursor);
+        LOGGER.debug("Commit [{}] ", cursor);
 
         try {
             consumerOffset.setOffset(cursor);
@@ -64,7 +72,7 @@ class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
 
     @Override
     public void flush(final EventTypePartition eventTypePartition) {
-        LOGGER.debug("flush {} ", eventTypePartition);
+        LOGGER.debug("Flush [{}] ", eventTypePartition);
     }
 
     @Override
@@ -76,7 +84,6 @@ class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
             LOGGER.error("Error [{}] reason [{}]", eventTypePartition, getMessage(t));
             ThrowableUtils.throwException(t);
         } else {
-
             eventErrorHandlers.forEach(eventErrorHandler ->
                     eventErrorHandler.onError(t, eventTypePartition, offset, rawEvent));
 
@@ -90,15 +97,17 @@ class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
             eventTypePartition);
 
         // error [412] / [{"type":"http://httpstatus.es/412","title":"Precondition
-        // Failed","status":412,"detail":"cursors are not valid"}]
-        if (resetStorageOnInvalidCursor && statusCode == 412 && content.contains(CURSORS_ARE_NOT_VALID)) {
+        // Failed","status":412,"detail":"offset 34505189 for partition 0 is unavailable"}]
+        if (deleteUnavailableCursors && statusCode == PRECONDITION_FAILED_HTTP_CODE
+                && CURSOR_NOT_AVAILABLE.matcher(content).find()) {
+
             final String path = consumerOffset.getOffsetPath(eventTypePartition.getName(),
                     eventTypePartition.getPartition());
             try {
                 LOGGER.warn("Delete consumer offset [{}] due to error [{}]", path, content);
                 consumerOffset.delOffset(path);
 
-                // partition will be restarted later and it with use new offset
+                // partition will be restarted later and it will use new offset
                 final PartitionRebalanceListener listener = rebalanceListenerProvider.getPartitionRebalanceListener(
                         eventTypePartition.getEventType());
                 if (null != listener) {
@@ -113,7 +122,8 @@ class ZKConsumerSyncOffsetManagement implements PartitionOffsetManagement {
         }
     }
 
-    public void setResetStorageOnInvalidCursor(final boolean resetStorageOnInvalidCursor) {
-        this.resetStorageOnInvalidCursor = resetStorageOnInvalidCursor;
+    void setDeleteUnavailableCursors(final boolean deleteUnavailableCursors) {
+        this.deleteUnavailableCursors = deleteUnavailableCursors;
     }
+
 }

--- a/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinator.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/main/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinator.java
@@ -165,9 +165,8 @@ public class ZKLeaderConsumerPartitionCoordinator extends AbstractZKConsumerPart
     }
 
     private void joinGroup(final EventType eventType) {
-        ZKGroupMember groupMember = groupMembers.get(eventType);
-        if (null == groupMember) {
-            groupMember = consumerGroupMember.newGroupMember(eventType, newGroupChangedListener());
+        if (!groupMembers.containsKey(eventType)) {
+            final ZKGroupMember groupMember = consumerGroupMember.newGroupMember(eventType, newGroupChangedListener());
             if (null == groupMembers.putIfAbsent(eventType, groupMember)) {
                 try {
                     log.info("Member [{}] is joining group for event type [{}] ", member.getMemberId(), eventType);

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerOffsetTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerOffsetTest.java
@@ -30,6 +30,6 @@ public class ZKConsumerOffsetTest extends AbstractZKTest {
         final String path = consumerOffset.getOffsetPath(etp.getName(), etp.getPartition());
         consumerOffset.delOffset(path);
         assertThat(consumerOffset.getOffset(etp.getEventType(), etp.getPartition())).isNull();
-
     }
+
 }

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementInvalidCursorsTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementInvalidCursorsTest.java
@@ -70,7 +70,7 @@ public class ZKConsumerSyncOffsetManagementInvalidCursorsTest extends AbstractZK
 
         zkConsumerSyncOffsetManagement.error(412,
             "{\"type\":\"http://httpstatus.es/412\",\"title\":\"Precondition Failed\",\"status\":412,\"detail\":\"offset 123 for partition 8 is unavailable\"}",
-            EventTypePartition.of(EventType.of(TEST_EVENT), TEST_PARTITION));
+            eventTypePartition);
 
         assertThat(consumerOffset.getOffset(eventTypePartition)).isNull();
 
@@ -90,7 +90,7 @@ public class ZKConsumerSyncOffsetManagementInvalidCursorsTest extends AbstractZK
 
         zkConsumerSyncOffsetManagement.error(412,
             "{\"type\":\"http://httpstatus.es/412\",\"title\":\"Precondition Failed\",\"status\":412,\"detail\":\"offset must not be null\"}",
-            EventTypePartition.of(EventType.of(TEST_EVENT), TEST_PARTITION));
+            eventTypePartition);
 
         assertThat(consumerOffset.getOffset(eventTypePartition)).isEqualTo("123");
     }

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementInvalidCursorsTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKConsumerSyncOffsetManagementInvalidCursorsTest.java
@@ -1,0 +1,98 @@
+package de.zalando.paradox.nakadi.consumer.partitioned.zk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Matchers.any;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.google.common.collect.Iterables;
+
+import de.zalando.paradox.nakadi.consumer.core.domain.EventType;
+import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
+import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
+import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionCommitCallbackProvider;
+import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionRebalanceListener;
+import de.zalando.paradox.nakadi.consumer.core.partitioned.PartitionRebalanceListenerProvider;
+
+public class ZKConsumerSyncOffsetManagementInvalidCursorsTest extends AbstractZKTest {
+
+    private static final String TEST_EVENT = "test-event";
+
+    private static final String TEST_PARTITION = "8";
+
+    private ZKConsumerSyncOffsetManagement zkConsumerSyncOffsetManagement;
+
+    private ZKConsumerOffset consumerOffset;
+
+    @Mock
+    private PartitionCommitCallbackProvider mockPartitionCommitCallbackProvider;
+
+    @Mock
+    private PartitionRebalanceListenerProvider mockPartitionRebalanceListenerProvider;
+
+    @Mock
+    private PartitionRebalanceListener mockPartitionRebalanceListener;
+
+    @Captor
+    private ArgumentCaptor<Collection<EventTypePartition>> partitionsCaptor;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.initMocks(this);
+        consumerOffset = new ZKConsumerOffset(zkHolder, "test-consumer");
+        zkConsumerSyncOffsetManagement = new ZKConsumerSyncOffsetManagement(consumerOffset,
+                mockPartitionCommitCallbackProvider, mockPartitionRebalanceListenerProvider, Collections.emptyList());
+    }
+
+    @Test
+    public void testShouldDeleteInvalidCursors() throws Exception {
+        when(mockPartitionRebalanceListenerProvider.getPartitionRebalanceListener(any(EventType.class))).thenReturn(
+            mockPartitionRebalanceListener);
+
+        final EventTypePartition eventTypePartition = EventTypePartition.of(EventType.of(TEST_EVENT), TEST_PARTITION);
+        consumerOffset.setOffset(EventTypeCursor.of(eventTypePartition, "123"));
+        zkConsumerSyncOffsetManagement.setDeleteUnavailableCursors(true);
+
+        zkConsumerSyncOffsetManagement.error(412,
+            "{\"type\":\"http://httpstatus.es/412\",\"title\":\"Precondition Failed\",\"status\":412,\"detail\":\"offset 123 for partition 8 is unavailable\"}",
+            EventTypePartition.of(EventType.of(TEST_EVENT), TEST_PARTITION));
+
+        assertThat(consumerOffset.getOffset(eventTypePartition)).isNull();
+
+        verify(mockPartitionRebalanceListener).onPartitionsRevoked(partitionsCaptor.capture());
+
+        final Collection<EventTypePartition> partitionsCaptorValue = partitionsCaptor.getValue();
+        assertThat(partitionsCaptorValue).hasSize(1);
+        assertThat(Iterables.getOnlyElement(partitionsCaptorValue).getEventType().getName()).isEqualTo(TEST_EVENT);
+        assertThat(Iterables.getOnlyElement(partitionsCaptorValue).getPartition()).isEqualTo(TEST_PARTITION);
+    }
+
+    @Test
+    public void testShouldNotDeleteCursorIfProvidedOffsetWasNull() throws Exception {
+        final EventTypePartition eventTypePartition = EventTypePartition.of(EventType.of(TEST_EVENT), TEST_PARTITION);
+        consumerOffset.setOffset(EventTypeCursor.of(eventTypePartition, "123"));
+        zkConsumerSyncOffsetManagement.setDeleteUnavailableCursors(true);
+
+        zkConsumerSyncOffsetManagement.error(412,
+            "{\"type\":\"http://httpstatus.es/412\",\"title\":\"Precondition Failed\",\"status\":412,\"detail\":\"offset must not be null\"}",
+            EventTypePartition.of(EventType.of(TEST_EVENT), TEST_PARTITION));
+
+        assertThat(consumerOffset.getOffset(eventTypePartition)).isEqualTo("123");
+    }
+
+}


### PR DESCRIPTION
- Remove reasoning about cursor offset validity in `AbstractZKConsumerPartitionCoordinator`
- Delete cursors from ZooKeeper in case of offset being not available
Exception handling is based on message in https://github.com/zalando/nakadi/blob/efbe08322a32cc9108a69abe81407088edb2bad2/src/main/java/org/zalando/nakadi/exceptions/InvalidCursorException.java#L33

- Call `sync()` before reading offset from ZooKeeper 

https://zookeeper.apache.org/doc/r3.4.9/zookeeperProgrammers.html#ch_zkGuarantees
> Simultaneously Consistent Cross-Client Views
ZooKeeper does not guarantee that at every instance in time, two different clients will have identical views of ZooKeeper data. Due to factors like network delays, one client may perform an update before another client gets notified of the change. Consider the scenario of two clients, A and B. If client A sets the value of a znode /a from 0 to 1, then tells client B to read /a, client B may read the old value of 0, depending on which server it is connected to. If it is important that Client A and Client B read the same value, Client B should should call the sync() method from the ZooKeeper API method before it performs its read. 