### PR TITLE
Fetch unconsumed events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,8 +192,9 @@ project(":paradox-nakadi-consumer-core") {
         compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:${jacksonVersion}"
         compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"
         compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
-        testCompile("com.github.tomakehurst:wiremock:1.57")
-        testCompile("commons-io:commons-io:2.5")
+        testCompile "com.github.tomakehurst:wiremock:1.57"
+        testCompile "commons-io:commons-io:2.5"
+        testCompile "com.squareup.okhttp3:mockwebserver:3.6.0"
     }
 }
 

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/client/Client.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/client/Client.java
@@ -15,4 +15,7 @@ public interface Client {
     Single<String> getEvent(final EventTypeCursor cursor);
 
     Single<String> getContent(final EventTypeCursor cursor);
+
+    Single<List<NakadiPartition>> getCursorsLag(final List<EventTypeCursor> cursors);
+
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/client/impl/ClientImpl.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/client/impl/ClientImpl.java
@@ -3,6 +3,7 @@ package de.zalando.paradox.nakadi.consumer.core.client.impl;
 import static java.util.Objects.requireNonNull;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
 
@@ -10,21 +11,24 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 
 import de.zalando.paradox.nakadi.consumer.core.AuthorizationValueProvider;
-import de.zalando.paradox.nakadi.consumer.core.ConsumerConfig;
 import de.zalando.paradox.nakadi.consumer.core.DefaultObjectMapper;
 import de.zalando.paradox.nakadi.consumer.core.EventStreamConfig;
 import de.zalando.paradox.nakadi.consumer.core.client.Client;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventType;
 import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
+import de.zalando.paradox.nakadi.consumer.core.domain.NakadiCursor;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiEventBatch;
 import de.zalando.paradox.nakadi.consumer.core.domain.NakadiPartition;
 import de.zalando.paradox.nakadi.consumer.core.http.HttpResponseChunk;
@@ -34,10 +38,23 @@ import de.zalando.paradox.nakadi.consumer.core.http.requests.HttpGetEvents;
 import de.zalando.paradox.nakadi.consumer.core.http.requests.HttpGetPartitions;
 import de.zalando.paradox.nakadi.consumer.core.utils.ThrowableUtils;
 
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
 import rx.Observable;
 import rx.Single;
 
 public class ClientImpl implements Client {
+
+    private static final TypeReference<List<NakadiPartition>> NAKADI_PARTITIONS_TYPE =
+        new TypeReference<List<NakadiPartition>>() { };
+
+    private static final MediaType CONTENT_TYPE = MediaType.parse("application/json");
 
     private final String nakadiUrl;
 
@@ -49,20 +66,14 @@ public class ClientImpl implements Client {
 
     private final long eventsTimeoutMillis;
 
-    public ClientImpl(final ClientImpl.Builder builder) {
+    private final OkHttpClient okHttpClient = initHttpClient();
+
+    private ClientImpl(final ClientImpl.Builder builder) {
         this.nakadiUrl = requireNonNull(builder.nakadiUrl, "nakadiUrl must not be null");
         this.objectMapper = requireNonNull(builder.objectMapper, "objectMapper must not be null");
         this.authorizationValueProvider = builder.authorizationValueProvider;
         this.partitionsTimeoutMillis = builder.partitionsTimeoutMillis;
         this.eventsTimeoutMillis = builder.eventsTimeoutMillis;
-    }
-
-    public ClientImpl(final ConsumerConfig consumerConfig) {
-        this.nakadiUrl = consumerConfig.getNakadiUrl();
-        this.objectMapper = consumerConfig.getObjectMapper();
-        this.authorizationValueProvider = consumerConfig.getAuthorizationValueProvider();
-        this.partitionsTimeoutMillis = consumerConfig.getPartitionsTimeoutMillis();
-        this.eventsTimeoutMillis = consumerConfig.getEventsTimeoutMillis();
     }
 
     @Override
@@ -98,6 +109,36 @@ public class ClientImpl implements Client {
     public Single<String> getContent(final EventTypeCursor cursor) {
         final Observable<HttpResponseChunk> request = getContent0(cursor, 1);
         return request.map(HttpResponseChunk::getContent).firstOrDefault(null).toSingle();
+    }
+
+    @Override
+    public Single<List<NakadiPartition>> getCursorsLag(final List<EventTypeCursor> cursors) {
+        checkNotNull(cursors, "cursors must not be null");
+        checkArgument(!cursors.isEmpty(), "cursors must not be empty");
+        checkArgument(cursors.stream().map(EventTypeCursor::getEventType).distinct().count() == 1,
+            "cursors must contain cursors of only one type");
+
+        return Single.<List<NakadiPartition>>fromCallable(() -> {
+                final EventType eventType = cursors.get(0).getEventType();
+                final HttpUrl httpUrl = HttpUrl.parse(nakadiUrl).newBuilder().addPathSegment("event-types")
+                        .addPathSegment(eventType.getName()).addPathSegment("cursors-lags").build();
+                final Request request = new Request.Builder().url(httpUrl).post(
+                        RequestBody.create(CONTENT_TYPE, //
+                            getNakadiCursors(cursors))) //
+                    .build();
+                final Response response = okHttpClient.newCall(request).execute();
+                if (response.isSuccessful()) {
+                    return objectMapper.readValue(response.body().byteStream(), NAKADI_PARTITIONS_TYPE);
+                } else {
+                    throw new RuntimeException(response.body().string());
+                }
+            });
+    }
+
+    private String getNakadiCursors(final List<EventTypeCursor> cursors) throws JsonProcessingException {
+        final List<NakadiCursor> nakadiCursors = cursors.stream().map(cursor ->
+                    new NakadiCursor(cursor.getPartition(), cursor.getOffset())).collect(Collectors.toList());
+        return objectMapper.writeValueAsString(nakadiCursors);
     }
 
     private Observable<HttpResponseChunk> getContent0(final EventTypeCursor cursor, final int streamLimit) {
@@ -169,4 +210,24 @@ public class ClientImpl implements Client {
     ObjectMapper getObjectMapper() {
         return objectMapper;
     }
+
+    @VisibleForTesting
+    OkHttpClient initHttpClient() {
+        return new OkHttpClient.Builder().addInterceptor(getAuthorizationInterceptor()).build();
+    }
+
+    private Interceptor getAuthorizationInterceptor() {
+        return new Interceptor() {
+            @Override
+            public Response intercept(final Chain chain) throws IOException {
+                if (authorizationValueProvider != null) {
+                    return chain.proceed(chain.request().newBuilder().addHeader("Authorization",
+                                "Bearer" + authorizationValueProvider.get()).build());
+                } else {
+                    return chain.proceed(chain.request());
+                }
+            }
+        };
+    }
+
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/domain/NakadiPartition.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/domain/NakadiPartition.java
@@ -1,5 +1,10 @@
 package de.zalando.paradox.nakadi.consumer.core.domain;
 
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -15,12 +20,19 @@ public class NakadiPartition {
 
     private final String newestAvailableOffset;
 
+    private final Long unconsumedEvents;
+
+    @JsonCreator
     public NakadiPartition(@JsonProperty("partition") final String partition,
             @JsonProperty("oldest_available_offset") final String oldestAvailableOffset,
-            @JsonProperty("newest_available_offset") final String newestAvailableOffset) {
+            @JsonProperty("newest_available_offset") final String newestAvailableOffset,
+            @Nullable
+            @JsonProperty("unconsumed_events")
+            final Long unconsumedEvents) {
         this.partition = partition;
         this.oldestAvailableOffset = oldestAvailableOffset;
         this.newestAvailableOffset = newestAvailableOffset;
+        this.unconsumedEvents = unconsumedEvents;
     }
 
     public String getPartition() {
@@ -35,25 +47,37 @@ public class NakadiPartition {
         return newestAvailableOffset;
     }
 
+    public Optional<Long> getUnconsumedEvents() {
+        return Optional.ofNullable(unconsumedEvents);
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).add("partition", partition)
                           .add("oldestAvailableOffset", oldestAvailableOffset)
-                          .add("newestAvailableOffset", newestAvailableOffset).toString();
+                          .add("newestAvailableOffset", newestAvailableOffset).add("unconsumedEvents", unconsumedEvents)
+                          .toString();
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         NakadiPartition that = (NakadiPartition) o;
-        return Objects.equal(partition, that.partition) &&
-                Objects.equal(oldestAvailableOffset, that.oldestAvailableOffset) &&
-                Objects.equal(newestAvailableOffset, that.newestAvailableOffset);
+        return Objects.equal(partition, that.partition)
+                && Objects.equal(oldestAvailableOffset, that.oldestAvailableOffset)
+                && Objects.equal(newestAvailableOffset, that.newestAvailableOffset)
+                && Objects.equal(unconsumedEvents, that.unconsumedEvents);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(partition, oldestAvailableOffset, newestAvailableOffset);
+        return Objects.hashCode(partition, oldestAvailableOffset, newestAvailableOffset, unconsumedEvents);
     }
 }

--- a/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/okhttp/RxHttpRequest.java
+++ b/paradox-nakadi-consumer-core/src/main/java/de/zalando/paradox/nakadi/consumer/core/http/okhttp/RxHttpRequest.java
@@ -158,7 +158,6 @@ public class RxHttpRequest {
 
         final Map<String, String> result = new HashMap<>(headers);
         final String value = authorizationValueProvider.get();
-        LOGGER.debug("Authorization header value '{}'", value);
         result.put(AUTHORIZATION_HEADER, value);
         return result;
     }

--- a/paradox-nakadi-consumer-core/src/test/java/de/zalando/paradox/nakadi/consumer/core/client/impl/ClientImplIT.java
+++ b/paradox-nakadi-consumer-core/src/test/java/de/zalando/paradox/nakadi/consumer/core/client/impl/ClientImplIT.java
@@ -1,0 +1,67 @@
+package de.zalando.paradox.nakadi.consumer.core.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.common.collect.Iterables;
+
+import de.zalando.paradox.nakadi.consumer.core.client.Client;
+import de.zalando.paradox.nakadi.consumer.core.domain.EventType;
+import de.zalando.paradox.nakadi.consumer.core.domain.EventTypeCursor;
+import de.zalando.paradox.nakadi.consumer.core.domain.EventTypePartition;
+import de.zalando.paradox.nakadi.consumer.core.domain.NakadiPartition;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+public class ClientImplIT {
+
+    private static final EventType TEST_EVENT_TYPE = EventType.of("test-event");
+
+    private MockWebServer mockWebServer;
+
+    private Client client;
+
+    @Before
+    public void setUp() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        client = new ClientImpl.Builder(mockWebServer.url("/").toString()).withObjectMapper(new ObjectMapper()).build();
+    }
+
+    @Test
+    public void testShouldReturnNumberOfUnconsumedEvents() {
+        mockWebServer.enqueue(new MockResponse().setBody(
+                "[{\"partition\": \"0\", \"oldest_available_offset\" : \"0\", \"newest_available_offset\": \"838282\", \"unconsumed_events\": 838282}]"));
+
+        final List<NakadiPartition> nakadiPartitions = client.getCursorsLag(Collections.singletonList(
+                                                                     EventTypeCursor.of(
+                                                                         EventTypePartition.of(TEST_EVENT_TYPE, "0"),
+                                                                         "BEGIN"))).toBlocking().value();
+
+        final NakadiPartition nakadiPartition = Iterables.getOnlyElement(nakadiPartitions);
+        assertThat(nakadiPartition.getOldestAvailableOffset()).isEqualTo("0");
+        assertThat(nakadiPartition.getNewestAvailableOffset()).isEqualTo("838282");
+        assertThat(nakadiPartition.getUnconsumedEvents()).contains(838282L);
+    }
+
+    @Test
+    public void testShouldReturnExceptionIfNumberOfUnconsumedEventsCannotBeFetched() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500).setBody("expected error"));
+        assertThatThrownBy(() -> {
+                                      final List<NakadiPartition> nakadiPartitions = client.getCursorsLag(
+                                              Collections.singletonList(
+                                                  EventTypeCursor.of(EventTypePartition.of(TEST_EVENT_TYPE, "0"),
+                                                      "BEGIN"))).toBlocking().value();
+                                  }).isInstanceOf(RuntimeException.class).hasMessage("expected error");
+    }
+
+}

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinatorTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionCoordinatorTest.java
@@ -43,7 +43,7 @@ public class ZKLeaderConsumerPartitionCoordinatorTest extends AbstractZKTest {
         final String memberId = "member-1";
 
         final String partition = "0";
-        final NakadiPartition nakadiPartition = new NakadiPartition(partition, "BEGIN", "0");
+        final NakadiPartition nakadiPartition = new NakadiPartition(partition, "BEGIN", "0", 0L);
         final Collection<NakadiPartition> nakadiPartitions = Collections.singleton(nakadiPartition);
         final EventTypePartitions consumerPartitons = new EventTypePartitions(EVENT_TYPE,
                 Collections.singleton(partition));
@@ -74,7 +74,7 @@ public class ZKLeaderConsumerPartitionCoordinatorTest extends AbstractZKTest {
         final String memberId2 = "member-2";
 
         final String partition = "0";
-        final NakadiPartition nakadiPartition = new NakadiPartition(partition, "BEGIN", "0");
+        final NakadiPartition nakadiPartition = new NakadiPartition(partition, "BEGIN", "0", 0L);
         final Collection<NakadiPartition> nakadiPartitions = Collections.singleton(nakadiPartition);
         final EventTypePartitions consumerPartitons = new EventTypePartitions(EVENT_TYPE,
                 Collections.singleton(partition));

--- a/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionRebalanceStrategyTest.java
+++ b/paradox-nakadi-consumer-partitioned-zk/src/test/java/de/zalando/paradox/nakadi/consumer/partitioned/zk/ZKLeaderConsumerPartitionRebalanceStrategyTest.java
@@ -259,7 +259,7 @@ public class ZKLeaderConsumerPartitionRebalanceStrategyTest {
     }
 
     private NakadiPartition nakadiPartition(final String partition) {
-        return new NakadiPartition(partition, "0", "0");
+        return new NakadiPartition(partition, "0", "0", 0L);
     }
 
     private Map<String, ZKMember> newCurrentMember(final ZKMember... members) {


### PR DESCRIPTION
This allows to get the number of unconsumed events, i.e., consumer lag, from within an external monitoring application.